### PR TITLE
Add basic WebSocket room server and real client

### DIFF
--- a/app/[roomId]/page.tsx
+++ b/app/[roomId]/page.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { wsClient } from "@/lib/websocket-client"
+import { useGameState } from "@/hooks/use-game-state"
+import { useSearchParams } from "next/navigation"
+
+export default function RoomPage({ params }: { params: { roomId: string } }) {
+  const search = useSearchParams()
+  const [playerId] = useState(
+    () => search.get("playerId") || Math.random().toString(36).substring(2, 9),
+  )
+
+  const { players } = useGameState(playerId)
+
+  useEffect(() => {
+    wsClient.connect(params.roomId, playerId)
+    return () => {
+      wsClient.disconnect()
+    }
+  }, [params.roomId, playerId])
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Room {params.roomId}</h1>
+      <h2 className="mt-4">Players</h2>
+      <ul className="list-disc pl-4">
+        {players.map((p) => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/websocket-server.ts
+++ b/websocket-server.ts
@@ -1,0 +1,126 @@
+import { createServer } from "http"
+import { createHash } from "crypto"
+
+interface RoomMap {
+  [roomId: string]: Map<string, import("net").Socket>
+}
+
+const rooms: RoomMap = {}
+
+function broadcast(roomId: string, message: any) {
+  const room = rooms[roomId]
+  if (!room) return
+  const data = JSON.stringify(message)
+  for (const socket of room.values()) {
+    send(socket, data)
+  }
+}
+
+function send(socket: import("net").Socket, data: string) {
+  const jsonBuffer = Buffer.from(data)
+  const frame = Buffer.alloc(2 + jsonBuffer.length)
+  frame[0] = 0x81 // FIN + text frame
+  frame[1] = jsonBuffer.length
+  jsonBuffer.copy(frame, 2)
+  socket.write(frame)
+}
+
+function parseMessage(buffer: Buffer): string | null {
+  const firstByte = buffer[0]
+  const opcode = firstByte & 0x0f
+  if (opcode === 0x8) return null // connection close
+  let offset = 2
+  let length = buffer[1] & 0x7f
+  if (length === 126) {
+    length = buffer.readUInt16BE(offset)
+    offset += 2
+  } else if (length === 127) {
+    // Note: only support 32-bit length
+    length = buffer.readUInt32BE(offset + 4)
+    offset += 8
+  }
+  const mask = buffer.slice(offset, offset + 4)
+  offset += 4
+  const data = buffer.slice(offset, offset + length)
+  for (let i = 0; i < data.length; i++) {
+    data[i] ^= mask[i % 4]
+  }
+  return data.toString("utf8")
+}
+
+const server = createServer()
+
+server.on("upgrade", (req, socket) => {
+  const key = req.headers["sec-websocket-key"] as string
+  const accept = createHash("sha1")
+    .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    .digest("base64")
+
+  const headers = [
+    "HTTP/1.1 101 Switching Protocols",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Accept: ${accept}`,
+    "\r\n",
+  ]
+
+  socket.write(headers.join("\r\n"))
+
+  let currentRoom: string | null = null
+  let currentPlayer: string | null = null
+
+  socket.on("data", (buffer) => {
+    const msg = parseMessage(buffer)
+    if (!msg) return
+    try {
+      const data = JSON.parse(msg)
+      if (data.type === "CONNECT") {
+        currentRoom = data.roomId
+        currentPlayer = data.playerId
+        rooms[currentRoom] = rooms[currentRoom] || new Map()
+        rooms[currentRoom].set(currentPlayer, socket)
+        send(
+          socket,
+          JSON.stringify({
+            type: "ROOM_JOINED",
+            payload: { roomId: currentRoom, playerId: currentPlayer },
+            timestamp: new Date(),
+          }),
+        )
+        broadcast(currentRoom, {
+          type: "PLAYER_LIST_UPDATED",
+          payload: {
+            players: Array.from(rooms[currentRoom].keys()),
+          },
+          timestamp: new Date(),
+        })
+      } else if (currentRoom) {
+        broadcast(currentRoom, data)
+      }
+    } catch (err) {
+      send(socket, JSON.stringify({ type: "ERROR", message: "Invalid message" }))
+    }
+  })
+
+  socket.on("close", () => {
+    if (currentRoom && currentPlayer && rooms[currentRoom]) {
+      rooms[currentRoom].delete(currentPlayer)
+      broadcast(currentRoom, {
+        type: "PLAYER_LIST_UPDATED",
+        payload: {
+          players: Array.from(rooms[currentRoom].keys()),
+        },
+        timestamp: new Date(),
+      })
+      if (rooms[currentRoom].size === 0) {
+        delete rooms[currentRoom]
+      }
+    }
+  })
+})
+
+const PORT = process.env.WS_PORT ? parseInt(process.env.WS_PORT) : 3001
+server.listen(PORT, () => {
+  console.log(`WebSocket server running on port ${PORT}`)
+})
+


### PR DESCRIPTION
## Summary
- add lightweight Node WebSocket server managing rooms and player lists
- implement real WebSocket client to connect and exchange events
- update game state hook and new room page to sync player list via ROOM_JOINED and PLAYER_LIST_UPDATED

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68aac77c2bac8323812037f6ebe9d86d