### PR TITLE
feat: add modal for room join and basic admin flow

### DIFF
--- a/app/[roomId]/page.tsx
+++ b/app/[roomId]/page.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useState } from "react"
+import { PlayerNameModal } from "@/components/room/player-name-modal"
+import { useRealtimeGame } from "@/hooks/use-realtime-game"
+import type { Player } from "@/lib/types"
+
+const ROOM_PASSWORDS: Record<string, string> = {
+  "210899": "1234",
+}
+
+export default function RoomPage({ params }: { params: { roomId: string } }) {
+  const { roomId } = params
+  const [player, setPlayer] = useState<Player | null>(null)
+
+  const handleJoin = (name: string, isAdmin: boolean) => {
+    const id = "player-" + Math.random().toString(36).substring(2, 9)
+    setPlayer({
+      id,
+      name,
+      isOwner: isAdmin,
+      isAlive: true,
+      isMuted: false,
+      hasShield: false,
+      connectedAt: new Date(),
+    })
+  }
+
+  if (!player) {
+    return (
+      <PlayerNameModal
+        roomId={roomId}
+        adminPassword={ROOM_PASSWORDS[roomId]}
+        onSubmit={handleJoin}
+      />
+    )
+  }
+
+  const { players, connectionStatus, sendEvent } = useRealtimeGame(
+    roomId,
+    player.id,
+    player.name,
+    player.isOwner,
+  )
+
+  const handleKick = (id: string) => {
+    sendEvent("PLAYER_KICKED", { playerId: id })
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Oda {roomId}</h1>
+      <p className="text-sm text-muted-foreground">Durum: {connectionStatus}</p>
+      <ul className="space-y-1">
+        {players.map((p) => (
+          <li key={p.id} className="flex items-center gap-2">
+            <span>
+              {p.name}
+              {p.id === player.id ? " (sen)" : ""}
+              {p.isOwner ? " [yönetici]" : ""}
+            </span>
+            {player.isOwner && p.id !== player.id && (
+              <button
+                className="text-red-500 text-sm"
+                onClick={() => handleKick(p.id)}
+              >
+                At
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/components/room/player-name-modal.tsx
+++ b/components/room/player-name-modal.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useState } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
+
+interface PlayerNameModalProps {
+  roomId: string
+  adminPassword?: string
+  onSubmit: (name: string, isAdmin: boolean) => void
+}
+
+export function PlayerNameModal({ roomId, adminPassword, onSubmit }: PlayerNameModalProps) {
+  const [name, setName] = useState("")
+  const [isAdmin, setIsAdmin] = useState(false)
+  const [password, setPassword] = useState("")
+
+  const canSave = name.trim().length > 0 && (!isAdmin || password === adminPassword)
+
+  return (
+    <Dialog open onOpenChange={() => {}}>
+      <DialogContent className="max-w-sm bg-card border-border" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Oda {roomId}</DialogTitle>
+          <DialogDescription>Lütfen isminizi girin</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="player-name">İsim</Label>
+            <Input
+              id="player-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Adınız"
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox id="is-admin" checked={isAdmin} onCheckedChange={(v) => setIsAdmin(!!v)} />
+            <Label htmlFor="is-admin">Yönetici</Label>
+          </div>
+          {isAdmin && (
+            <div className="space-y-2">
+              <Label htmlFor="admin-password">Şifre</Label>
+              <Input
+                id="admin-password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Yönetici şifresi"
+              />
+            </div>
+          )}
+        </div>
+        <Button className="w-full" disabled={!canSave} onClick={() => onSubmit(name.trim(), isAdmin)}>
+          Kaydet
+        </Button>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/lib/websocket-client.ts
+++ b/lib/websocket-client.ts
@@ -15,6 +15,7 @@ export type GameEvent =
   | "VOTE_CAST"
   | "VOTE_RESULT"
   | "PLAYER_ELIMINATED"
+  | "PLAYER_KICKED"
   | "PLAYER_REVIVED"
   | "WINNER_DECLARED"
   | "GAME_ENDED"
@@ -37,6 +38,8 @@ export class WebSocketClient extends EventEmitter {
   private reconnectInterval = 3000
   private roomId: string | null = null
   private playerId: string | null = null
+  private playerName: string | null = null
+  private isOwner = false
 
   constructor() {
     super()
@@ -51,9 +54,11 @@ export class WebSocketClient extends EventEmitter {
     }, 1000)
   }
 
-  connect(roomId: string, playerId: string) {
+  connect(roomId: string, playerId: string, playerName: string, isOwner: boolean) {
     this.roomId = roomId
     this.playerId = playerId
+    this.playerName = playerName
+    this.isOwner = isOwner
 
     if (!this.connected) {
       this.simulateConnection()
@@ -64,6 +69,26 @@ export class WebSocketClient extends EventEmitter {
       this.emit("ROOM_JOINED", {
         type: "ROOM_JOINED",
         payload: { roomId, playerId },
+        timestamp: new Date(),
+        roomId,
+        playerId,
+      })
+
+      this.emit("PLAYER_LIST_UPDATED", {
+        type: "PLAYER_LIST_UPDATED",
+        payload: {
+          players: [
+            {
+              id: playerId,
+              name: playerName,
+              isOwner,
+              isAlive: true,
+              isMuted: false,
+              hasShield: false,
+            },
+          ],
+          newPlayer: { name: playerName },
+        },
         timestamp: new Date(),
         roomId,
         playerId,


### PR DESCRIPTION
## Summary
- add player name modal with optional admin password
- enable dynamic room pages and track players via realtime hook
- extend realtime hooks and ws client for basic admin actions

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68aacce1483c8323bf874210ac989365