### PR TITLE
Enable realtime rooms and refine gameplay flow

### DIFF
--- a/components/game/card-drawing-phase.tsx
+++ b/components/game/card-drawing-phase.tsx
@@ -8,7 +8,6 @@ interface CardDrawingPhaseProps {
   selectedCardDrawers: string[]
   currentCardDrawer: string | null
   currentPlayerId: string
-  timeRemaining: number
   onCardDrawn: () => void
 }
 
@@ -17,7 +16,6 @@ export function CardDrawingPhase({
   selectedCardDrawers,
   currentCardDrawer,
   currentPlayerId,
-  timeRemaining,
   onCardDrawn,
 }: CardDrawingPhaseProps) {
   const [isScanning, setIsScanning] = useState(false)
@@ -44,7 +42,6 @@ export function CardDrawingPhase({
       <div className="max-w-2xl w-full text-center space-y-8">
         <div className="space-y-4">
           <h1 className="text-4xl font-bold text-white mb-2">🎴 Kart Çekme Zamanı</h1>
-          <div className="text-cyan-400 text-lg">Süre: {timeRemaining}s</div>
         </div>
 
         <div className="bg-slate-800/50 backdrop-blur-sm border border-purple-500/30 rounded-xl p-8 shadow-2xl">

--- a/components/game/game-controller.tsx
+++ b/components/game/game-controller.tsx
@@ -112,7 +112,6 @@ export function GameController({ initialPlayers, gameSettings, currentPlayerId, 
           selectedCardDrawers={selectedCardDrawers}
           currentCardDrawer={currentCardDrawer}
           currentPlayerId={currentPlayerId}
-          timeRemaining={timeRemaining}
           onCardDrawn={advancePhase}
         />
       )

--- a/hooks/use-game-state.ts
+++ b/hooks/use-game-state.ts
@@ -103,6 +103,7 @@ export function useGameState(currentPlayerId: string): GameStateHook {
   }, [])
 
   const processNightActions = useCallback(() => {
+    // Step 1: Guardians block their targets in timestamp order
     const blockedPlayers = new Set<string>()
     const guardianActions = nightActions
       .filter((action) => {
@@ -123,10 +124,36 @@ export function useGameState(currentPlayerId: string): GameStateHook {
       }
     })
 
+    // Step 2: Resolve kills from unblocked killers
     const killers = nightActions.filter(
       (action) => action.actionType === "KILL" && !blockedPlayers.has(action.playerId),
     )
     const killTargets = killers.map((k) => k.targetId).filter(Boolean) as string[]
+
+    // Step 3: Resolve doctor revives after kills
+    const revivedPlayers = new Set<string>()
+    const doctorResults = new Map<string, { success: boolean }>()
+    nightActions
+      .filter((action) => {
+        const actor = players.find((p) => p.id === action.playerId)
+        return action.actionType === "PROTECT" && actor?.role === "DOCTOR"
+      })
+      .forEach((action) => {
+        const actor = players.find((p) => p.id === action.playerId)
+        const target = action.targetId ? players.find((p) => p.id === action.targetId) : null
+        if (!actor || blockedPlayers.has(actor.id)) {
+          doctorResults.set(action.playerId, { success: false })
+          return
+        }
+        if (target && (!target.isAlive || killTargets.includes(target.id))) {
+          revivedPlayers.add(target.id)
+          doctorResults.set(action.playerId, { success: true })
+        } else {
+          doctorResults.set(action.playerId, { success: false })
+        }
+      })
+
+    // Step 4: process remaining actions (watchers, survivors, bombs, etc.)
     const bombPlacers = nightActions.filter(
       (a) => a.actionType === "BOMB_PLANT" && !blockedPlayers.has(a.playerId),
     )
@@ -141,7 +168,6 @@ export function useGameState(currentPlayerId: string): GameStateHook {
 
     const protectedPlayers = new Set<string>()
     const survivorActors = new Set<string>()
-    const revivedPlayers = new Set<string>()
 
     let detonateIndex = -1
 
@@ -167,11 +193,9 @@ export function useGameState(currentPlayerId: string): GameStateHook {
             result = { type: "PROTECT", remaining }
           }
         } else if (actor.role === "DOCTOR") {
-          if (target && (!target.isAlive || killTargets.includes(target.id))) {
-            revivedPlayers.add(target.id)
-            result = { type: "REVIVE", success: true }
-          } else {
-            result = { type: "REVIVE", success: false }
+          const docResult = doctorResults.get(actor.id)
+          if (docResult) {
+            result = { type: "REVIVE", success: docResult.success }
           }
         } else if (action.targetId) {
           protectedPlayers.add(action.targetId)

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -6,16 +6,95 @@ const app = express();
 const server = http.createServer(app);
 const wss = new WebSocket.Server({ server });
 
-wss.on('connection', function connection(ws) {
-  console.log('Yeni bağlantı geldi.');
+// In-memory room and player tracking
+const rooms = new Map(); // roomId -> { players: Map<playerId, player>, sockets: Set<ws> }
 
+function broadcastPlayerList(roomId, options = {}) {
+  const room = rooms.get(roomId);
+  if (!room) return;
+  const players = Array.from(room.players.values());
+  const message = JSON.stringify({
+    type: 'PLAYER_LIST_UPDATED',
+    payload: {
+      players,
+      ...(options.newPlayer ? { newPlayer: options.newPlayer } : {}),
+      ...(options.removedPlayer ? { removedPlayer: options.removedPlayer } : {}),
+    },
+  });
+  room.sockets.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(message);
+    }
+  });
+}
+
+wss.on('connection', function connection(ws) {
   ws.on('message', function incoming(message) {
-    console.log('Gelen mesaj:', message);
-    ws.send(`Echo: ${message}`);
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (e) {
+      console.error('Invalid message', e);
+      return;
+    }
+
+    const { type, payload, roomId, playerId } = data;
+
+    switch (type) {
+      case 'JOIN_ROOM': {
+        const { roomId: joinRoomId, player } = payload;
+        ws.roomId = joinRoomId;
+        ws.playerId = player.id;
+        if (!rooms.has(joinRoomId)) {
+          rooms.set(joinRoomId, { players: new Map(), sockets: new Set() });
+        }
+        const room = rooms.get(joinRoomId);
+        room.players.set(player.id, player);
+        room.sockets.add(ws);
+
+        ws.send(
+          JSON.stringify({ type: 'ROOM_JOINED', payload: { roomId: joinRoomId } }),
+        );
+
+        broadcastPlayerList(joinRoomId, { newPlayer: player });
+        break;
+      }
+
+      case 'KICK_PLAYER': {
+        const room = rooms.get(roomId);
+        if (!room) return;
+        const targetId = payload.playerId;
+        const removed = room.players.get(targetId);
+        const targetSocket = Array.from(room.sockets).find((s) => s.playerId === targetId);
+        if (targetSocket) {
+          targetSocket.send(
+            JSON.stringify({ type: 'PLAYER_KICKED', payload: { playerId: targetId } }),
+          );
+          targetSocket.close();
+        }
+        room.players.delete(targetId);
+        broadcastPlayerList(roomId, { removedPlayer: removed });
+        break;
+      }
+
+      default:
+        // Unknown events are ignored
+        break;
+    }
   });
 
   ws.on('close', () => {
-    console.log('Bağlantı kapandı.');
+    const { roomId, playerId } = ws;
+    if (roomId && rooms.has(roomId)) {
+      const room = rooms.get(roomId);
+      const removed = room.players.get(playerId);
+      room.players.delete(playerId);
+      room.sockets.delete(ws);
+      broadcastPlayerList(roomId, { removedPlayer: removed });
+      if (room.players.size === 0) {
+        rooms.delete(roomId);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Add room-aware WebSocket server broadcasting player lists so multiple devices see each other
- Ensure night roles resolve in order (guardians block, killers act, doctors revive)
- Remove timer from card drawing phase for manual QR scans

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d7959d883239c8d18b742699fbe