### PR TITLE
Fix Leaflet initialization with dynamic import

### DIFF
--- a/app/[roomId]/page.tsx
+++ b/app/[roomId]/page.tsx
@@ -1,12 +1,17 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import dynamic from "next/dynamic"
 import { RoomLobby } from "@/components/room/room-lobby"
 import { GameController } from "@/components/game/game-controller"
 import { JoinRoomDialog } from "@/components/room/join-room-dialog"
 import { wsClient } from "@/lib/websocket-client"
 import { useRealtimeGame } from "@/hooks/use-realtime-game"
 import type { Room, Player, GameSettings, GamePhase } from "@/lib/types"
+
+const LeafletMap = dynamic(() => import("@/components/leaflet-map"), {
+  ssr: false,
+})
 
 const ROOM_PASSWORD = "1234"
 
@@ -134,6 +139,7 @@ export default function RoomPage({ params }: { params: { roomId: string } }) {
           onGameEnd={handleGameEnd}
         />
       )}
+      <LeafletMap />
     </>
   )
 }

--- a/components/leaflet-map.tsx
+++ b/components/leaflet-map.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+export default function LeafletMap() {
+  const mapRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let map: any
+    const init = async () => {
+      const L = (await import("leaflet")).default
+      if (!mapRef.current) return
+      map = L.map(mapRef.current).setView([0, 0], 2)
+      L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
+      }).addTo(map)
+    }
+    init()
+    return () => {
+      if (map) {
+        map.remove()
+      }
+    }
+  }, [])
+
+  return <div ref={mapRef} className="h-64 w-full" />
+}

--- a/types/leaflet.d.ts
+++ b/types/leaflet.d.ts
@@ -1,0 +1,4 @@
+declare module "leaflet" {
+  const value: any
+  export default value
+}


### PR DESCRIPTION
## Summary
- load Leaflet map client-side only using next/dynamic
- add LeafletMap component with dynamic import
- stub module declaration for Leaflet

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab32ad0008832385906e47b5a22aec