### PR TITLE
fix: guard useIsMobile hook for server rendering

### DIFF
--- a/components/ui/use-mobile.tsx
+++ b/components/ui/use-mobile.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
@@ -6,6 +8,8 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
+    if (typeof window === "undefined") return
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)

--- a/hooks/use-mobile.ts
+++ b/hooks/use-mobile.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
@@ -6,6 +8,8 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
+    if (typeof window === "undefined") return
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)


### PR DESCRIPTION
## Summary
- mark mobile-detection hook as a client module
- guard against server-side window access

## Testing
- `npm test` (fails: Missing script "test")
- `pnpm run lint` (fails: ESLint must be installed)
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4daad95c83238ad09a9603e6be15