### PR TITLE
Broadcast game start to all room players

### DIFF
--- a/app/[roomId]/page.tsx
+++ b/app/[roomId]/page.tsx
@@ -89,6 +89,10 @@ export default function RoomPage({ params }: { params: { roomId: string } }) {
   const realtime = useRealtimeGame(currentRoom.id, currentPlayer)
 
   useEffect(() => {
+    setGamePhase(realtime.currentPhase)
+  }, [realtime.currentPhase])
+
+  useEffect(() => {
     const handleKicked = (data: any) => {
       if (data.payload.playerId === currentPlayer?.id) {
         setCurrentPlayer(null)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,5 +12,4 @@ const nextConfig = {
     unoptimized: true,
   },
 }
-module.exports = nextConfig;
 export default nextConfig

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -77,6 +77,18 @@ wss.on('connection', function connection(ws) {
         break;
       }
 
+      case 'GAME_STARTED': {
+        const room = rooms.get(roomId);
+        if (!room) return;
+        const message = JSON.stringify({ type: 'GAME_STARTED', payload });
+        room.sockets.forEach((client) => {
+          if (client.readyState === WebSocket.OPEN) {
+            client.send(message);
+          }
+        });
+        break;
+      }
+
       default:
         // Unknown events are ignored
         break;


### PR DESCRIPTION
## Summary
- broadcast `GAME_STARTED` messages to all sockets so players leave the lobby together
- sync room page state with realtime phase updates
- simplify Next.js config to ESM export so linting can run

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: GET https://registry.npmjs.org/eslint: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8dbffb9483239560554d3fb7334d